### PR TITLE
Implement homepage layout

### DIFF
--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,9 +1,22 @@
-import './App.css';
+import React from 'react';
+import './Marketplace.css';
+import Navbar from './components/Navbar';
+import SearchSection from './components/SearchSection';
+import CategoryGrid from './components/CategoryGrid';
+import ListingGrid from './components/ListingGrid';
+import AuthForms from './components/AuthForms';
 
 function App() {
   return (
-    
-    helo
+    <div className="app">
+      <Navbar />
+      <div className="container">
+        <SearchSection />
+        <CategoryGrid />
+        <ListingGrid />
+        <AuthForms />
+      </div>
+    </div>
   );
 }
 

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders search input', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const inputElement = screen.getByPlaceholderText(/what service do you need\?/i);
+  expect(inputElement).toBeInTheDocument();
 });

--- a/my-app/src/Marketplace.css
+++ b/my-app/src/Marketplace.css
@@ -26,6 +26,12 @@ body {
   line-height: 1.5;
 }
 
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
 /* Utility classes */
 a {
   text-decoration: none;
@@ -59,11 +65,21 @@ a {
   padding: 1rem 1.5rem;
   background-color: #fff;
   box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 
 .navbar .menu-right {
   display: flex;
   gap: 1rem;
+}
+
+.navbar select {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--color-gray);
+  border-radius: 0.25rem;
+  background-color: #fff;
 }
 
 /* Search area */
@@ -80,6 +96,12 @@ a {
   border-radius: 0.5rem;
 }
 
+.subtitle {
+  margin-top: 0.5rem;
+  color: var(--color-dark);
+  font-size: 0.875rem;
+}
+
 /* Popular categories */
 .categories {
   display: grid;
@@ -94,6 +116,12 @@ a {
   padding: 1rem;
   text-align: center;
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.category-card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 /* Latest listings */
@@ -109,6 +137,12 @@ a {
   border-radius: 0.5rem;
   padding: 1rem;
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.listing-card:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 /* 2. Login / Register Page ----------------------------------------------- */

--- a/my-app/src/components/AuthForms.js
+++ b/my-app/src/components/AuthForms.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+function AuthForms() {
+  const [type, setType] = useState('login');
+
+  return (
+    <section className="auth-container">
+      <div className="user-type-select">
+        <button className="btn" onClick={() => setType('login')}>Login</button>
+        <button className="btn" onClick={() => setType('register')}>Register</button>
+      </div>
+      {type === 'login' ? (
+        <form className="auth-form">
+          <input type="email" placeholder="Email" />
+          <input type="password" placeholder="Password" />
+          <div className="auth-actions">
+            <button className="btn" type="submit">Login</button>
+          </div>
+        </form>
+      ) : (
+        <form className="auth-form">
+          <input type="text" placeholder="Name" />
+          <input type="email" placeholder="Email" />
+          <input type="password" placeholder="Password" />
+          <div className="auth-actions">
+            <button className="btn" type="submit">Register</button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
+export default AuthForms;

--- a/my-app/src/components/CategoryGrid.js
+++ b/my-app/src/components/CategoryGrid.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const defaultCategories = [
+  { icon: '🎨', label: 'Design' },
+  { icon: '💻', label: 'Development' },
+  { icon: '✍️', label: 'Writing' },
+  { icon: '📈', label: 'Marketing' },
+  { icon: '🎬', label: 'Video' },
+  { icon: '🎵', label: 'Music' },
+  { icon: '🔧', label: 'Repairs' },
+  { icon: '🧹', label: 'Cleaning' }
+];
+
+function CategoryGrid({ categories = defaultCategories }) {
+  return (
+    <section className="categories">
+      {categories.map((cat, idx) => (
+        <div className="category-card" key={idx}>
+          <div>{cat.icon}</div>
+          <div>{cat.label}</div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export default CategoryGrid;

--- a/my-app/src/components/ListingGrid.js
+++ b/my-app/src/components/ListingGrid.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const defaultListings = [
+  {
+    title: 'Build a website',
+    description: 'Need a modern website for my business.'
+  },
+  {
+    title: 'Design a logo',
+    description: 'Looking for a fresh logo concept.'
+  },
+  {
+    title: 'Write blog articles',
+    description: 'Require weekly posts on technology.'
+  }
+];
+
+function ListingGrid({ listings = defaultListings }) {
+  return (
+    <section className="latest-listings">
+      {listings.map((item, idx) => (
+        <div className="listing-card" key={idx}>
+          <h3>{item.title}</h3>
+          <p>{item.description}</p>
+          <button className="btn">Make Offer</button>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export default ListingGrid;

--- a/my-app/src/components/Navbar.js
+++ b/my-app/src/components/Navbar.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+function Navbar() {
+  return (
+    <nav className="navbar">
+      <div className="logo">eSantiyem</div>
+      <div className="menu-right">
+        <select className="categories-dropdown">
+          <option>Categories</option>
+          <option>Design</option>
+          <option>Development</option>
+          <option>Marketing</option>
+        </select>
+        <button className="btn">Login</button>
+        <button className="btn">Register</button>
+      </div>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/my-app/src/components/SearchSection.js
+++ b/my-app/src/components/SearchSection.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function SearchSection() {
+  return (
+    <section className="search-container">
+      <input type="text" placeholder="What service do you need?" />
+      <p className="subtitle">Popular categories</p>
+    </section>
+  );
+}
+
+export default SearchSection;


### PR DESCRIPTION
## Summary
- add Inter font to `index.html`
- style main layout and card hovers
- create Navbar, Search, Category and Listing components
- add simple auth forms
- test that search input renders

## Testing
- `npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_6861af3017508320a1ddd942a671ca42