### PR TITLE
Add testimonials and brand strip to marketplace UI

### DIFF
--- a/my-app/src/Marketplace.css
+++ b/my-app/src/Marketplace.css
@@ -47,12 +47,13 @@ a {
   border-radius: 0.5rem;
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  transition: background-color 0.2s, box-shadow 0.2s;
+  transition: background-color 0.2s, box-shadow 0.2s, transform 0.2s;
 }
 
 .btn:hover {
   background-color: var(--color-primary-dark);
   box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+  transform: scale(1.05);
 }
 
 /* 1. Home Page ------------------------------------------------------------ */
@@ -106,6 +107,10 @@ a {
 .hero-section {
   padding: 3rem 1rem;
   text-align: center;
+  background-image: radial-gradient(circle at 20% 20%, rgba(249,115,22,0.15) 0, rgba(249,115,22,0.15) 25%, transparent 25%),
+    radial-gradient(circle at 80% 80%, rgba(249,115,22,0.15) 0, rgba(249,115,22,0.15) 25%, transparent 25%);
+  background-size: 150px 150px;
+  background-repeat: no-repeat;
 }
 
 .hero-section h1 {
@@ -173,6 +178,20 @@ a {
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
   transition: transform 0.2s, box-shadow 0.2s;
 }
+.listing-title {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 1.1rem;
+}
+.card-footer {
+  border-top: 1px solid var(--color-gray);
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  text-align: right;
+}
+
+
 
 .listing-card:hover {
   transform: scale(1.02);
@@ -190,6 +209,44 @@ a {
 }
 
 .cta-section .btn {
+  margin-top: 1rem;
+}
+
+/* Testimonials */
+.testimonials {
+  margin-top: 2rem;
+  padding: 1rem;
+}
+.testimonial-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.testimonial {
+  background-color: #fff;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  font-style: italic;
+}
+.testimonial .name {
+  margin-top: 0.5rem;
+  font-weight: 500;
+  text-align: right;
+}
+
+/* Brands strip */
+.brands-strip {
+  margin-top: 2rem;
+  padding: 1rem 0;
+  text-align: center;
+}
+.brands-list {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
   margin-top: 1rem;
 }
 

--- a/my-app/src/components/BrandsStrip.js
+++ b/my-app/src/components/BrandsStrip.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const brands = [1, 2, 3, 4];
+
+function BrandsStrip() {
+  return (
+    <section className="brands-strip">
+      <h3>Bize güvenen markalar</h3>
+      <div className="brands-list">
+        {brands.map((b) => (
+          <img
+            key={b}
+            src={`https://via.placeholder.com/80x40?text=Logo+${b}`}
+            alt="Marka logosu"
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default BrandsStrip;

--- a/my-app/src/components/ListingGrid.js
+++ b/my-app/src/components/ListingGrid.js
@@ -2,18 +2,22 @@ import React from 'react';
 
 const defaultListings = [
   {
+    icon: '🛁',
     title: 'Banyo Tadilatı',
     description: 'Duşakabin, fayans ve lavabo yenilemesi yapılacak.'
   },
   {
+    icon: '💡',
     title: 'Elektrik Arızası',
     description: 'Evimdeki prizler çalışmıyor, kontrol edilmesi gerekiyor.'
   },
   {
+    icon: '🪚',
     title: 'Parke Döşeme',
     description: 'Salon ve koridor için parke döşenecek.'
   },
   {
+    icon: '🧹',
     title: 'Temizlik Hizmeti',
     description: 'Haftalık detaylı ev temizliği yapılacak.'
   }
@@ -24,9 +28,11 @@ function ListingGrid({ listings = defaultListings }) {
     <section className="latest-listings">
       {listings.map((item, idx) => (
         <div className="listing-card" key={idx}>
-          <h3>{item.title}</h3>
+          <h3 className="listing-title">{item.icon} {item.title}</h3>
           <p>{item.description}</p>
-          <button className="btn">Teklif Ver</button>
+          <div className="card-footer">
+            <button className="btn">Teklif Ver</button>
+          </div>
         </div>
       ))}
     </section>

--- a/my-app/src/components/TestimonialsSection.js
+++ b/my-app/src/components/TestimonialsSection.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const testimonials = [
+  { quote: 'Harika bir hizmet, çok memnun kaldım.', name: 'Ayşe K.' },
+  { quote: 'Ustalar çok hızlı dönüş yaptılar.', name: 'Mehmet D.' },
+  { quote: 'Gönül rahatlığıyla tavsiye ederim.', name: 'Selin P.' }
+];
+
+function TestimonialsSection() {
+  return (
+    <section className="testimonials">
+      <h2>Kullanıcı Yorumları</h2>
+      <div className="testimonial-list">
+        {testimonials.map((t, idx) => (
+          <div className="testimonial" key={idx}>
+            <p className="quote">{t.quote}</p>
+            <p className="name">- {t.name}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default TestimonialsSection;

--- a/my-app/src/pages/HomePage.js
+++ b/my-app/src/pages/HomePage.js
@@ -4,6 +4,8 @@ import HeroSection from '../components/HeroSection';
 import CategoryGrid from '../components/CategoryGrid';
 import ListingGrid from '../components/ListingGrid';
 import CTASection from '../components/CTASection';
+import TestimonialsSection from '../components/TestimonialsSection';
+import BrandsStrip from '../components/BrandsStrip';
 
 function HomePage() {
   return (
@@ -14,6 +16,8 @@ function HomePage() {
         <CategoryGrid />
         <ListingGrid />
         <CTASection />
+        <TestimonialsSection />
+        <BrandsStrip />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make listing cards nicer with icons and a footer for the button
- add Testimonials and BrandsStrip sections
- add subtle background pattern, card footer styling, and hover effects
- tweak button hover style

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861bcee88a88320b6050daea60b957f